### PR TITLE
Improved performance

### DIFF
--- a/extension/src/common/info.cuh
+++ b/extension/src/common/info.cuh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <iostream>
 
 
 struct mru_general_info {
@@ -81,6 +82,12 @@ inline mru_scan_info get_scan_info(const uint state_width, const uint sequence_l
 
     const uint tiled_state_width = ceil_div(state_width, tile_width);
     const uint tiled_state_size = tiled_state_width * tiled_state_width;
+
+    if (32 % tiled_state_width != 0 && tiled_state_width % 32 != 0) {
+        std::cout << 
+        "because tiled_state_width is neither a factor of or evenly divisible by 32, this kernel will be unable to utilize warp broadcasting and will run slower."
+        << '\n';
+    }
 
     const uint state_row_size = state_width;
     const uint state_matrix_size = state_row_size * state_row_size;

--- a/extension/src/common/matmul.cuh
+++ b/extension/src/common/matmul.cuh
@@ -13,29 +13,30 @@ __device__ void matmul_matrices(
     uint tile_col,
     uint tile_row,
     
-    const uint matrix_width,
-    const uint matrix_shift
+    const uint matrix_size,
+    const uint matrix_width
 ) {
     scalar_t first_matrix_tile_cache[tile_width];
     scalar_t second_matrix_tile_cache[tile_width];
 
 
     for (uint matrix_depth = 0; matrix_depth < matrix_width; ++matrix_depth) {
+        // allow both indices to wrap around
+        tile_row %= matrix_size;
+        tile_col %= matrix_size;
+
         // load just a partial row of the source matrix and a partial column of the inplace matrix
+        #pragma unroll
         for (uint load_step = 0; load_step < tile_width; ++load_step) {
-            first_matrix_tile_cache[load_step] = first_matrix[tile_row];
-            second_matrix_tile_cache[load_step] = second_matrix[tile_col];
-            
-            // load tile_width elements from left to right
-            tile_row++;
-            tile_col++;
+            first_matrix_tile_cache[load_step] = first_matrix[tile_row + load_step];
+            second_matrix_tile_cache[load_step] = second_matrix[tile_col + load_step];
         }
         // set to the next row
-        tile_row += matrix_shift;
-        tile_col += matrix_shift;
+        tile_row += matrix_width;
+        tile_col += matrix_width;
+        
         
         uint result_tile_idx = 0;
-
         // perform partial matrix multiplication on just the tile
         for (uint row_idx = 0; row_idx < tile_width; ++row_idx) {
             for (uint col_idx = 0; col_idx < tile_width; ++col_idx) {    

--- a/extension/src/common/write_tile.cuh
+++ b/extension/src/common/write_tile.cuh
@@ -11,25 +11,23 @@ __device__ inline void write_tile(
     const uint tile_col,
     const uint tile_row,
 
-    const uint matrix_width,
-    const uint matrix_shift
+    const uint matrix_width
 ) {
     // index of the top left corner of the tile
     uint store_idx = tile_row * matrix_width + tile_col;
     uint result_tile_idx = 0;
 
     for (uint row_idx = 0; row_idx < tile_width; ++row_idx) {
+        #pragma unroll
         for (uint col_idx = 0; col_idx < tile_width; ++col_idx) {
             if constexpr (accumulate) {
-                target_matrix_tile[store_idx] += result_tile[result_tile_idx];
+                target_matrix_tile[store_idx + col_idx] += result_tile[result_tile_idx + col_idx];
             } else {
-                target_matrix_tile[store_idx] = result_tile[result_tile_idx];
+                target_matrix_tile[store_idx + col_idx]  = result_tile[result_tile_idx + col_idx];
             }
-
-            result_tile_idx++;
-            store_idx++;
         }
-        
-        store_idx += matrix_shift;
+
+        store_idx += matrix_width;
+        result_tile_idx += tile_width;
     }
 }

--- a/extension/src/mru_cuda_forward.cu
+++ b/extension/src/mru_cuda_forward.cu
@@ -90,11 +90,12 @@ __global__ void mru_cuda_forward_scan_stage_kernel(
     #define intra_matmul_thread_idx tile_idx
 
 
+    const uint intra_block_input_group_subidx = matmul_input_group_subidx % matmuls_per_block;
+
 
     // load the source matrix into smem
     __syncthreads();
     {
-        const uint intra_block_input_group_subidx = matmul_input_group_subidx % matmuls_per_block;
         const uint matmuls_per_source_matrix = min(matmuls_per_block, scan_stage_offset);
         const uint threads_per_source_matrix = threads_per_matmul * matmuls_per_source_matrix;
 
@@ -116,34 +117,32 @@ __global__ void mru_cuda_forward_scan_stage_kernel(
     copy_matrix<scalar_t>(inplace_matrix_gmem_ptr, inplace_matrix_smem_ptr, state_matrix_size, intra_matmul_thread_idx, threads_per_matmul);
     
     // compute the matmuls
-    {
-        const uint new_intra_block_matmul_idx = threadIdx.x % matmuls_per_block;
+    scalar_t result_tile[tile_size] = {0.0};
     
-        const uint new_source_matrix_smem_idx = new_intra_block_matmul_idx / scan_stage_offset;
-        const uint new_inplace_matrix_smem_idx = new_intra_block_matmul_idx;
-    
-        const scalar_t* const new_source_matrix_smem_ptr = &source_matrices_smem_cache[state_matrix_size * new_source_matrix_smem_idx];
-        /* */ scalar_t* const new_inplace_matrix_smem_ptr = &inplace_matrices_smem_cache[state_matrix_size * new_inplace_matrix_smem_idx];
-    
-    
-        scalar_t result_tile[tile_size] = {0.0};
-    
-    
-        const uint tile_idx = threadIdx.x / matmuls_per_block;
-    
-        // coords of the top left corner of the tile
-        const uint tile_col = tile_width * (tile_idx % tiled_state_width);
-        const uint tile_row = tile_width * (tile_idx / tiled_state_width);
-    
-        // move to the next row, then shift back tile_width to reset all the way to the left
-        const uint matrix_shift = state_row_size - tile_width;
-    
-        __syncthreads();
-        matmul_matrices<scalar_t, tile_width>(result_tile, new_source_matrix_smem_ptr, new_inplace_matrix_smem_ptr, tile_col, tile_row, state_row_size, matrix_shift);
-    
-        __syncthreads();
-        write_tile<scalar_t, tile_width, false>(result_tile, new_inplace_matrix_smem_ptr, tile_col, tile_row, state_row_size, matrix_shift);
-    }
+    // coords of the top left corner of the tile
+    const uint tile_col = tile_width * (tile_idx % tiled_state_width);
+    const uint tile_row = tile_width * (tile_idx / tiled_state_width);
+
+    // move to the next row, then shift back tile_width to reset all the way to the left
+    const uint matrix_shift = state_row_size - tile_width;
+
+    __syncthreads();
+    matmul_matrices<scalar_t, tile_width>(
+        result_tile,
+
+        source_matrix_smem_ptr,
+        inplace_matrix_smem_ptr,
+
+        tile_col + state_row_size * (tile_row / (4 * 32)),
+        tile_row + state_row_size * intra_block_input_group_subidx,
+
+        state_matrix_size,
+        state_row_size,
+        matrix_shift
+    );
+
+    __syncthreads();
+    write_tile<scalar_t, tile_width, false>(result_tile, inplace_matrix_smem_ptr, tile_col, tile_row, state_row_size, matrix_shift);
 
 
     // write results from smem back to gmem


### PR DESCRIPTION
Offset the partial matrix multiplications to avoid bank conflicts in shared memory and simplify the code